### PR TITLE
Change resize() to bind('resize',...) to be compatible with jQuery 1.3.x

### DIFF
--- a/jail.js
+++ b/jail.js
@@ -169,7 +169,7 @@
 		// Check if there are images to load
 		if (!!triggerEl && typeof triggerEl.bind === "function") {
 			triggerEl.bind( options.event, {options:options, images : images}, _bufferedEventListener );
-			$window.resize( {options:options, images : images}, _bufferedEventListener );
+			$window.bind('resize', {options:options, images : images}, _bufferedEventListener );
 		}
 	}
 


### PR DESCRIPTION
...to 1.4.3, so this will throw an error in any jQuery 1.3 version.  Using bind() resolves the issue.
