### PR TITLE
Update jail.js

### DIFF
--- a/src/jail.js
+++ b/src/jail.js
@@ -342,10 +342,9 @@
 					$img[options.effect]();
 				}
 				$img.css("opacity", 1);
-				$img.show();
-			} else {
-				$img.show();
 			}
+			$img.show();
+			
 		
 			_purgeStack(currentStack);
 		


### PR DESCRIPTION
"$img.show();" (line 346) can be outside the if... and else... So the else-block isn't needed anymore (line 346).
