### PR TITLE
Add option for for defining data attribute

### DIFF
--- a/src/jail.js
+++ b/src/jail.js
@@ -191,6 +191,7 @@
 	* Remove any elements that have been loaded from the jQuery stack.
 	* This should speed up subsequent calls by not having to iterate over the loaded elements.
 	*
+	* @param options : configurations object
 	* @param stack : current images stack
 	*/
 	function _purgeStack ( options, stack ) {
@@ -258,6 +259,7 @@
 	/* 
 	* Check if all the images are loaded
 	*
+	* @param options : configurations object
 	* @param images : images under analysis
 	* @return boolean
 	*/


### PR DESCRIPTION
Add option for for defining data attribute; defaults to data-src. Allows configurable data-attribute - have separate calls on the same page, different timing, effects, offset, etc. 
