### PR TITLE
Let the amd loader handle jquery loading.

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,7 +158,7 @@ requirejs.config({
     }
 });
 
-require(["jquery", "app/jail"], function() {
+require(["jquery", "app/jail"], function($) {
     $(function(){
 		$('img.lazy').jail();
 	});

--- a/demo/js/require-main.js
+++ b/demo/js/require-main.js
@@ -4,10 +4,6 @@ requirejs.config({
     
     paths: {
         app: '../src'
-    },
-
-    shim: {
-        'app/jail': ['jquery']
     }
 });
 

--- a/demo/js/require-main2.js
+++ b/demo/js/require-main2.js
@@ -4,14 +4,10 @@ requirejs.config({
     
     paths: {
         app: '../src'
-    },
-
-    shim: {
-        'app/jail': ['jquery']
     }
 });
 
-require(["jquery", "app/jail"], function() {
+require(["jquery", "app/jail"], function($) {
     $(function(){
 		$('img.lazy').each(function(i){
 			$(this).jail({

--- a/src/jail.js
+++ b/src/jail.js
@@ -24,7 +24,7 @@
 
 	if ( hasDefine ){  // AMD module
 
-		define( name , ['jquery'], definition );
+		define( ['jquery'], definition );
 		
 	}  else { // assign 'jail' to global objects
 		


### PR DESCRIPTION
This way, we dont need to specify a shim for jail and as a plus we can now use requirejs optimizer with jQuery on a CDN.
